### PR TITLE
Deploy to curate-qa.curationexperts.com

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+server 'curate-qa.curationexperts.com', user: 'deploy', roles: [:ubuntu]
+namespace :deploy do
+  after :finishing, :restart_apache do
+    on roles(:ubuntu) do
+      execute :sudo, :systemctl, :restart, :apache2
+    end
+  end
+end


### PR DESCRIPTION
* Note that we are making an ubuntu-specific target so it will skip Emory's `systemctl restart httpd` command and instead run Ubuntu's expected `systemctl restart apache2` command