### PR TITLE
Add sidekiq configuration

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,14 @@
+---
+  :queues:
+    - [ingest, 4]
+    - [batch, 2]
+    - [default, 1]
+
+  test: # n/a
+    :concurrency: 1
+
+  development:
+    :concurrency: <%= ENV['SIDEKIQ_WORKERS'] || 1 %>
+
+  production:
+    :concurrency: <%= ENV['SIDEKIQ_WORKERS'] || 5 %>


### PR DESCRIPTION
Set sidekiq queue names
Set default concurrency settings
Allow concurrency to be overridden by an environment variable:
ENV['SIDEKIQ_WORKERS']